### PR TITLE
Improved hash functions for integer items

### DIFF
--- a/count_min_sketch.cpp
+++ b/count_min_sketch.cpp
@@ -79,7 +79,7 @@ void CountMinSketch::update(int item, int c) {
   total = total + c;
   unsigned int hashval = 0;
   for (unsigned int j = 0; j < d; j++) {
-    hashval = (hashes[j][0]*item+hashes[j][1])%w;
+    hashval = ((long)hashes[j][0]*item+hashes[j][1])%LONG_PRIME%w;
     C[j][hashval] = C[j][hashval] + c;
   }
 }
@@ -95,7 +95,7 @@ unsigned int CountMinSketch::estimate(int item) {
   int minval = numeric_limits<int>::max();
   unsigned int hashval = 0;
   for (unsigned int j = 0; j < d; j++) {
-    hashval = (hashes[j][0]*item+hashes[j][1])%w;
+    hashval = ((long)hashes[j][0]*item+hashes[j][1])%LONG_PRIME%w;
     minval = MIN(minval, C[j][hashval]);
   }
   return minval;

--- a/count_min_sketch.hpp
+++ b/count_min_sketch.hpp
@@ -5,7 +5,7 @@
 **/
 
 // define some constants
-# define LONG_PRIME 32993
+# define LONG_PRIME 4294967311l
 # define MIN(a,b)  (a < b ? a : b)
 
 /** CountMinSketch class definition here **/


### PR DESCRIPTION
For larger integers, the current code was causing significant collisions. Improved it by increasing the range of values that `a` and `b` can take and made the hash function use a prime modulus first.